### PR TITLE
Strokes: tessellate thick strokes to triangles so joint and cap styles apply

### DIFF
--- a/lib/draw/GraphicsFactoryStrokes.ts
+++ b/lib/draw/GraphicsFactoryStrokes.ts
@@ -38,9 +38,34 @@ export class GraphicsFactoryStrokes {
 			const path = paths[i];
 			const style = (<GraphicsStrokeStyle<any>>path.style);
 
-			shape = targetGraphics.popEmptyStrokeShape();
-
 			path.prepare();
+
+			// Thick strokes are tessellated to triangles so joint styles (miter/bevel/
+			// round) and cap styles actually apply: GPU-expanded LineElements draw every
+			// segment as an independent quad and cannot form joints, which leaves a
+			// notch at each corner of a polyline. Hairlines and very thin strokes keep
+			// the fast LineElements path — joints are invisible at those sizes.
+			if (style.scaleMode !== LineScaleMode.HAIRLINE && style.thickness > 1.5) {
+				const triElements = this.getTriangleElements([path], false, style.scaleMode);
+
+				if (triElements) {
+					const triData = {
+						style: new Style(),
+						sampler: new ImageSampler(),
+						material: null
+					};
+
+					UnpackFillStyle[path.style.fillStyle.data_type](path.style.fillStyle, triData);
+
+					shape = Shape.getShape(triElements, triData.material, triData.style);
+
+					targetGraphics.addShapeInternal(shape);
+				}
+
+				continue;
+			}
+
+			shape = targetGraphics.popEmptyStrokeShape();
 
 			// if (targetGraphics.scaleStrokes != null) { //use LineElements
 			const elements = this.fillLineElements(


### PR DESCRIPTION
# Strokes: tessellate thick strokes to triangles so joint and cap styles apply

This PR makes `lineStyle` joint styles (miter/bevel/round) and cap styles work
for runtime-drawn strokes. Currently a polyline drawn with e.g.
`JointStyle.MITER` renders with a notch at every corner:

**before** — each segment is an independent quad, corners are two butt ends;
**after** — corners are proper mitered joints (or bevel/round as requested).

<img width="568" height="642" alt="image" src="https://github.com/user-attachments/assets/9c1711a3-d002-4a0a-bab5-721ce735f0ec" />

## The bug

`GraphicsFactoryStrokes.draw_pathes` is hardcoded to build strokes as
GPU-expanded `LineElements`. Each segment is expanded to a quad independently,
so no joint geometry can exist between segments — the requested `JointStyle`
and `CapsStyle` on interior corners are ignored by construction. A
commented-out branch in `draw_pathes` suggests there used to be a choice of
path here.

Meanwhile `getTriangleElements` — a complete CPU tessellation with full
miter/bevel/round joint handling and cap support (including the miter-limit
clamp) — is unreachable: nothing in the codebase calls it.

## The fix

Route non-hairline strokes thicker than 1.5px through `getTriangleElements`,
using the same `UnpackFillStyle` material path that fills use. Hairlines and
very thin strokes keep the fast `LineElements` path, where joints are
invisible anyway.

Bookkeeping: triangle-built stroke shapes are created fresh via
`Shape.getShape` (not from the LineElements stroke pool); `tryPoolShape`
already routes triangle shapes to the triangle pool, and the existing
`_lastStroke` remove-and-rebuild mechanism works unchanged.

## Real-world impact

Found reviving an AS3/Flex-era charting app under AwayFL: 8px chart polylines
drawn with `JointStyle.MITER, miterLimit 255` rendered with a visible notch at
every data point. With this change the peaks render as sharp mitered corners,
matching Flash. Verified against the app end-to-end (charts, plus a sweep of
other pages for stroke regressions).
